### PR TITLE
Extend `contains_envinfo` to account for new Issue Template

### DIFF
--- a/lib/bot/template.rb
+++ b/lib/bot/template.rb
@@ -72,7 +72,7 @@ module Bot
 
     def contains_envinfo?(issue)
       body = strip_comments(issue.body)
-      body =~ /Packages: \(wanted => installed\)/ || body =~ /React Native Environment Info:/ || body =~ /Environment:/ || body =~ /React Native version:/
+      body =~ /Packages: \(wanted => installed\)/ || body =~ /React Native Environment Info:/ || body =~ /Environment:/ || body =~ /React Native version:/ || body =~ /Output of `react-native info`/
     end
 
     def strip_comments(text)


### PR DESCRIPTION
I'm extending the `contains_envinfo` to account also for new issue templates where the environment info is always available. See this one for example: https://github.com/facebook/react-native/issues/32507