### PR TITLE
link to the Discussions root with "Releases" label

### DIFF
--- a/lib/bot/events.rb
+++ b/lib/bot/events.rb
@@ -39,7 +39,7 @@ module Bot
                 end
 
                 unless ENV['READ_ONLY'].present?
-                  Octokit.add_comment(@repo, pr_number, "This pull request was successfully merged by #{commit_author} in **#{commit.sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/1)</sup>")
+                  Octokit.add_comment(@repo, pr_number, "This pull request was successfully merged by #{commit_author} in **#{commit.sha}**.\n\n<sup>[When will my fix make it into a release?](https://github.com/facebook/react-native/wiki/Release-FAQ#when-will-my-fix-make-it-into-a-release) | [Upcoming Releases](https://github.com/reactwg/react-native-releases/discussions/categories/releases)</sup>")
                   Octokit.add_labels_to_an_issue(@repo, pr_number, [@label_pr_merged])
                   # Octokit.lock_issue(@repo, pr_number, { :lock_reason => "resolved", :accept => "application/vnd.github.sailor-v-preview+json" })
                 end


### PR DESCRIPTION
Current approach to the Upcoming Versions would require to update a link with every released version.

We can replace this link with link to the discussions list and use the "Releases" tag to filter out not necessary in this context discussions.

CC: @cortinico 